### PR TITLE
Update HttpServletResponseCopier.java

### DIFF
--- a/src/main/java/io/github/sercasti/tracing/domain/HttpServletResponseCopier.java
+++ b/src/main/java/io/github/sercasti/tracing/domain/HttpServletResponseCopier.java
@@ -57,6 +57,7 @@ public class HttpServletResponseCopier extends HttpServletResponseWrapper {
 
     @Override
     public boolean isCommitted() {
+        if(copier == null) return false;
         return copier.isCommitted();
     }
 


### PR DESCRIPTION
In my app, the isCommited() was called before the "copier" was able to be set.  This small change allowed things to work.

