### PR TITLE
Use tracing.disabled as @ConfigurationProperties instead of @Value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/io/github/sercasti/tracing/filter/TracingFilter.java
+++ b/src/main/java/io/github/sercasti/tracing/filter/TracingFilter.java
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -20,12 +21,20 @@ import io.github.sercasti.tracing.domain.HttpServletResponseCopier;
 
 @Component
 @Order(1)
+@ConfigurationProperties(prefix = "tracing")
 public class TracingFilter extends OncePerRequestFilter {
 
     static final ThreadLocal<TracingImpl> tracingLocal = new ThreadLocal<>();
 
-    @Value("${tracing.disabled}")
-    private final boolean disabled = false;
+    private boolean disabled = false;
+
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    public void setDisabled(boolean disabled) {
+        this.disabled = disabled;
+    }
 
     @Override
     protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain)

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,8 @@
+{
+  "properties": [
+    {
+      "name": "tracing.disabled",
+      "defaultValue": false
+    }
+  ]
+}


### PR DESCRIPTION
I've changed `TracingFilter` to use `tracing.disabled` as `@ConfigurationProperties` instead of `@Value`, for support of IDE.

**As-is**

![image](https://user-images.githubusercontent.com/6624567/106565809-bad30200-6572-11eb-9fab-1fb2b0189945.png)

**To-be**

![image](https://user-images.githubusercontent.com/6624567/106565823-c0304c80-6572-11eb-938a-0636a889c7b9.png)

Reference: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-vs-value