### PR TITLE
Added new Traceable fields for custom name and description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.sercasti</groupId>
     <artifactId>spring-httpserver-timings</artifactId>
-    <version>0.0.4</version>
+    <version>0.0.5</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -28,6 +28,14 @@
             <organizationUrl>https://github.com/sercasti</organizationUrl>
         </developer>
     </developers>
+    <contributors>
+        <contributor>
+            <name>Raja Anbazhagan</name>
+            <email>raja.anbazhagan1991@gmail.com</email>
+            <organization>Personal</organization>
+            <organizationUrl>https://github.com/raja-anbazhagan</organizationUrl>
+        </contributor>
+    </contributors>
 
     <scm>
         <connection>scm:git:git://github.com/sercasti/spring-httpserver-timings.git</connection>

--- a/src/main/java/io/github/sercasti/tracing/Traceable.java
+++ b/src/main/java/io/github/sercasti/tracing/Traceable.java
@@ -16,4 +16,12 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Traceable {
+    /**
+     * An optional name to identify a method in the Server-Timing response header.
+     * <p>
+     * Helpful to avoid showing internal method names to public or to distinguish between methods with similar names.
+     */
+    String name() default "";
+
+    String description() default "";
 }

--- a/src/main/java/io/github/sercasti/tracing/interceptor/TracingInterceptor.java
+++ b/src/main/java/io/github/sercasti/tracing/interceptor/TracingInterceptor.java
@@ -1,18 +1,15 @@
 package io.github.sercasti.tracing.interceptor;
 
 import io.github.sercasti.tracing.Traceable;
+import io.github.sercasti.tracing.core.Metric;
+import io.github.sercasti.tracing.core.Tracing;
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import io.github.sercasti.tracing.core.Metric;
-import io.github.sercasti.tracing.core.Tracing;
-
-import java.lang.reflect.Method;
+import org.springframework.util.StringUtils;
 
 @Aspect
 @Component
@@ -31,8 +28,8 @@ public class TracingInterceptor {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
 
         Traceable traceable = signature.getMethod().getAnnotation(Traceable.class);
-        String traceName = traceable.name().isEmpty() ? signature.getName() : traceable.name();
-        String traceDescription = traceable.description().isEmpty() ? null : traceable.description();
+        String traceName = StringUtils.isEmpty(traceable.name()) ? signature.getName() : traceable.name();
+        String traceDescription = StringUtils.isEmpty(traceable.description()) ? null : traceable.description();
 
         final Metric metric = tracing.start(traceName, traceDescription);
 


### PR DESCRIPTION
@sercasti, Great library BTW. You have the core implementation for Trace's name and description. However, it could be extended at the @Traceable annotation level as from `joinPoint.getSignature()`. 

As the annotation only targets methods, we can safely cast it to a MethodSignature and retrieve the actual annotation values. Hope this is a valuable addition to your library.   